### PR TITLE
support switch ssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: all build container push clean test
 
-TAG ?= 0.0.3
+TAG ?= 0.0.4
 PREFIX ?= upmcenterprises
 
 all: container


### PR DESCRIPTION
When [ElasticSearch operator](https://github.com/upmc-enterprises/elasticsearch-operator) set the flag use-ssl to false, then the snapshot job encounter issue, due to the scheme is always [https](https://github.com/upmc-enterprises/elasticsearch-cron/blob/master/main.go#L57)

Hence, I create this PR to accept flag --use-ssl to switch the scheme