### PR TITLE
Support for GCS Snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ CronJob container to perform snapshots of an elasticsearch cluster
 The container takes the following args:
 
 - action: Action to perform (repository or snapshot)
-- s3-bucket-name: Name of s3 bucket
+- repo-type: Type of repository, s3 or gcs.
+- bucket-name: Name of s3 or gcs bucket
 - elastic-url: Full dns url to elasticsearch
 - auth-username: Authentication username (if applicable)
 - auth-password: Authentication password (if applicable)


### PR DESCRIPTION
- Add `repo-type` arg to pass through either `s3` or `gcs` to the ES API call. 
- Rename `s3-bucket-name` to `bucket-name`

Depends on https://github.com/upmc-enterprises/elasticsearch-operator/pull/209